### PR TITLE
Round percentum in output message

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -83,7 +83,7 @@ const opportunities = lighthouseResult => {
   return sortOn(ret, 'label');
 };
 
-const convertToPercentum = num => num * 100;
+const convertToPercentum = num => Math.round(num * 100);
 
 module.exports = (parameters, response) => {
   return Promise.resolve().then(() => {


### PR DESCRIPTION
To fix messages like `Threshold of 70 not met with score of 14.000000000000002`